### PR TITLE
Fixes dover_tag byte count in memory allocator

### DIFF
--- a/bsp/libwrap/stdlib/malloc.c
+++ b/bsp/libwrap/stdlib/malloc.c
@@ -265,7 +265,7 @@ void * pvPortMalloc( size_t xWantedSize )
   }
 
   if(pvReturn)
-    pvReturn = dover_tag(pvReturn, xWantedSize - heapSTRUCT_SIZE);
+    pvReturn = dover_tag(pvReturn, pxBlock->xBlockSize - heapSTRUCT_SIZE);
   //        else
   //          printk("malloc allocation failure, size = %d\n", xWantedSize);
 


### PR DESCRIPTION
Sometimes the memory allocator hands out a block with a `xBlockSize` larger than `xWantedSize + heapSTRUCT_SIZE` (when the spare block is larger than the requested size, but too small to be split into two blocks). 

In this case, we need to `dover_tag` the entire block (except the header area), instead of just the first `xWantedSize` bytes. If we don't tag the entire block, we will run into heap color mismatch policy violation when we later free the block, since `pvPortFree` always `dover_untag` the entire block.

Potential downside: If we tag the entire block, out-of-bounds accesses that still fall inside the same block will not be caught. But they should be relatively harmless. Also, currently we already round up the requested size to the next whole word, so we already have this issue (to a lesser extent).