### PR TITLE
Write to zero in malloc to remove ModColor tag from the stack

### DIFF
--- a/vcu118/wrap/malloc.c
+++ b/vcu118/wrap/malloc.c
@@ -159,6 +159,7 @@ void * __attribute__ ((noinline)) dover_tag(volatile uintptr_t *ptr, size_t byte
     p++;
     count++;
   }
+  zero = 0;
   //printk("do_tag %x\n", dover_remove_tag(p));
 
   return res;
@@ -185,6 +186,7 @@ void __attribute__ ((noinline)) dover_untag(volatile uintptr_t *ptr, size_t byte
     p++;
     count++;
   }
+  zero = 0;
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Add a write to the end of `malloc` to store to the stack so that the heap policy can remove the `ModColor` tag and prevent it from propagating to other parts of memory.  Goes along with draperlaboratory/hope-policies#112.