### PR TITLE
Fix configuration of clock Hz for AP UART

### DIFF
--- a/vcu118/Makefile
+++ b/vcu118/Makefile
@@ -7,14 +7,14 @@ ifneq ($(ARCH), rv64)
 RISCV_ARCH 			 ?= rv32ima
 RISCV_ABI        ?= ilp32
 CFLAGS += --target=riscv32-unknown-elf
-CFLAGS += -DCPU_CLOCK_HZ=100000000
+CFLAGS += -DCPU_CLOCK_HZ=50000000
 else
 RISCV_ARCH ?= rv64imafd
 RISCV_ABI ?= lp64d
 
 CFLAGS += --target=riscv64-unknown-elf
 CFLAGS += -mcmodel=medany
-CFLAGS += -DCPU_CLOCK_HZ=50000000
+CFLAGS += -DCPU_CLOCK_HZ=100000000
 endif
 
 CFLAGS += -O0 -g3 -Wall -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI)


### PR DESCRIPTION
Fix the vcu118 bsp Makefile so that the P2 processor's UART is correctly configured with a clock rate of 100MHz and the P1 UART is configured with 50MHz.