### PR TITLE
SBRK Wrapper

### DIFF
--- a/vcu118/Makefile
+++ b/vcu118/Makefile
@@ -37,6 +37,7 @@ C_SRCS = init.c \
 				 wrap/puts.c \
 				 wrap/read.c \
 				 wrap/write.c \
+				 wrap/sbrk.c \
 			   xilinx/common/xbasic_types.c \
 				 xilinx/common/xil_io.c \
 				 xilinx/common/xil_assert.c \

--- a/vcu118/wrap/sbrk.c
+++ b/vcu118/wrap/sbrk.c
@@ -6,23 +6,32 @@ extern uintptr_t _heap_end;
 static void* program_break = &_heap_end;
 static uint32_t sbrk_zero = 0;
 
+uint32_t* const AP_MB0 = (uint32_t*)0x10090U;
+uint32_t* const AP_MB1 = (uint32_t*)0x10094U;
+uint32_t* const AP_MB2 = (uint32_t*)0x10098U;
+uint32_t* const AP_MB3 = (uint32_t*)0x1009cU;
+
 void* __wrap_sbrk(intptr_t increment)
 {
   // If increment is zero, just return the fake program break
   if (increment == 0)
     return program_break;
 
+  *AP_MB0 = 1;
+
   // Ensure the new program break always aligns to pointer size
   increment = (increment + sizeof(uintptr_t) - 1)/sizeof(uintptr_t)*sizeof(uintptr_t);
 
   // Move the fake program break
+  *AP_MB1 = (uint32_t)program_break;
   void* temp = program_break;
   program_break += increment;
+  *AP_MB2 = (uint32_t)program_break;
 
   // Update tags for newly-allocated or deallocated memory
   uintptr_t size = increment > 0 ? increment : -increment;
-  uint32_t* to_tag = (uint32_t*)(increment > 0 ? temp : program_break);
-  for (intptr_t i = 0; i < size/sizeof(uint32_t); i++)
+  volatile uintptr_t* to_tag = (uintptr_t*)(increment > 0 ? temp : program_break);
+  for (intptr_t i = 0; i < size/sizeof(uintptr_t); i++)
     to_tag[i] = sbrk_zero;
 
   return temp;

--- a/vcu118/wrap/sbrk.c
+++ b/vcu118/wrap/sbrk.c
@@ -4,11 +4,27 @@
 
 extern uintptr_t _heap_end;
 static void* program_break = &_heap_end;
+static uint32_t sbrk_zero = 0;
 
 void* __wrap_sbrk(intptr_t increment)
 {
+  // If increment is zero, just return the fake program break
+  if (increment == 0)
+    return program_break;
+
+  // Ensure the new program break always aligns to pointer size
+  increment = (increment + sizeof(uintptr_t) - 1)/sizeof(uintptr_t)*sizeof(uintptr_t);
+
+  // Move the fake program break
   void* temp = program_break;
   program_break += increment;
+
+  // Update tags for newly-allocated or deallocated memory
+  uintptr_t size = increment > 0 ? increment : -increment;
+  uint32_t* to_tag = (uint32_t*)(increment > 0 ? temp : program_break);
+  for (intptr_t i = 0; i < size/sizeof(uint32_t); i++)
+    to_tag[i] = sbrk_zero;
+
   return temp;
 }
 

--- a/vcu118/wrap/sbrk.c
+++ b/vcu118/wrap/sbrk.c
@@ -1,0 +1,18 @@
+#include <stdint.h>
+
+#include "weak_under_alias.h"
+
+extern uintptr_t _heap_end;
+static void* program_break = &_heap_end;
+
+void* __wrap_sbrk(intptr_t increment)
+{
+  void* temp = program_break;
+  program_break += increment;
+  return temp;
+}
+
+void* __wrap__sbrk(intptr_t increment)
+{
+  return __wrap_sbrk(increment);
+}

--- a/vcu118/wrap/sbrk.c
+++ b/vcu118/wrap/sbrk.c
@@ -6,10 +6,7 @@ extern uintptr_t _heap_end;
 static void* program_break = &_heap_end;
 static const volatile uintptr_t sbrk_zero = 0;
 
-uint32_t* const AP_MB0 = (uint32_t*)0x10090U;
-uint32_t* const AP_MB1 = (uint32_t*)0x10094U;
-uint32_t* const AP_MB2 = (uint32_t*)0x10098U;
-uint32_t* const AP_MB3 = (uint32_t*)0x1009cU;
+uint32_t* const AP_MB = (uint32_t*)0x10090U;
 
 void* __wrap_sbrk(intptr_t increment)
 {
@@ -17,16 +14,16 @@ void* __wrap_sbrk(intptr_t increment)
   if (increment == 0)
     return program_break;
 
-  *AP_MB0 = 1;
+  AP_MB[0] = 1;
 
   // Ensure the new program break always aligns to pointer size
   increment = (increment + sizeof(uintptr_t) - 1)/sizeof(uintptr_t)*sizeof(uintptr_t);
 
   // Move the fake program break
-  *AP_MB1 = (uint32_t)program_break;
+  AP_MB[1] = (uint32_t)program_break;
   void* temp = program_break;
   program_break += increment;
-  *AP_MB2 = (uint32_t)program_break;
+  AP_MB[2] = (uint32_t)program_break;
 
   // Update tags for newly-allocated or deallocated memory
   uintptr_t size = increment > 0 ? increment : -increment;

--- a/vcu118/wrap/sbrk.c
+++ b/vcu118/wrap/sbrk.c
@@ -2,6 +2,8 @@
 
 #include "weak_under_alias.h"
 
+#define SBRK_REQ 1
+
 extern uintptr_t _heap_end;
 static void* program_break = &_heap_end;
 static const volatile uintptr_t sbrk_zero = 0;
@@ -27,7 +29,7 @@ void* __wrap_sbrk(intptr_t increment)
 
   if (increment > 0) {
     // Interrupt the PEX to tell it the AP might want to allocate a new memory region
-    AP_MB[0] = 1;
+    AP_MB[0] = SBRK_REQ;
     uint32_t pex = PEX_MB[0];
     *MB_IRQ = 1;
     while (PEX_MB[0] == pex); // Wait for the PEX to finish processing the request

--- a/vcu118/wrap/sbrk.c
+++ b/vcu118/wrap/sbrk.c
@@ -4,7 +4,7 @@
 
 extern uintptr_t _heap_end;
 static void* program_break = &_heap_end;
-static uint32_t sbrk_zero = 0;
+static const volatile uintptr_t sbrk_zero = 0;
 
 uint32_t* const AP_MB0 = (uint32_t*)0x10090U;
 uint32_t* const AP_MB1 = (uint32_t*)0x10094U;


### PR DESCRIPTION
Adds a wrapper around the `sbrk` system call that fakes the program break by basically just keeping track of where it is and moving the pointer as `sbrk` is called.  Whenever `sbrk` is called, if the request is to expand the available memory (even if it's to re-expand it after shrinking it), the AP will send a message to the PEX using the PIPE's mailbox mechanism, including an interrupt.  The PEX is then expected to make any changes to the data TMT that are necessary.