### PR TITLE
* Enable interrupts, set up the mtvec, and print a simple

### DIFF
--- a/vcu118/boot.S
+++ b/vcu118/boot.S
@@ -73,7 +73,8 @@
 /* Startup code */
 .globl boot
 boot:
-    li t6, 0x1800
+	// enable MSTATUS_PRV1 and MSTATUS_MIE
+    li t6, 0x1888
     csrw mstatus, t6
     j _mstart
 

--- a/vcu118/init.c
+++ b/vcu118/init.c
@@ -3,12 +3,30 @@
 
 extern int main(void);
 
+#define write_csr(reg, val) \
+  asm volatile ("csrw " #reg ", %0" :: "r"(val))
+
+#define read_csr(reg) ({ unsigned long __tmp;               \
+            asm volatile ("csrr %0, " #reg : "=r"(__tmp));  \
+            __tmp; })
+
+void bad_trap(){
+  unsigned long mepc, mtval, mcause;
+  asm volatile("csrr %0, mcause" : "=r"(mcause));
+  asm volatile("csrr %0, mtval" : "=r"(mtval));
+  asm volatile("csrr %0, mepc" : "=r"(mepc));
+  printf("\n FAILURE: \n mcause=0x%lx\n, mepc=0x%lx \n, mtval=0x%lx \n", mcause, mepc, mtval);
+}
+
 void _init(void)
 {
   int result;
 
   uart0_init();
 
+   // set up a bad trap handler
+  write_csr(mtvec, ((uintptr_t)&bad_trap));
+  
   // set up floating point computation
   uintptr_t misa, mstatus;
   asm volatile("csrr %0, misa" : "=r"(misa));


### PR DESCRIPTION
 debug msg when a trap occurs so we know the mtval, mepc, and mcause.